### PR TITLE
Disable wave effects on Realtime control when starting and when "press-to-talk" is not pressed

### DIFF
--- a/Navbot.RealtimeApi.Dotnet.SDK/Navbot.RealtimeApi.Dotnet.SDK.WPF.Sample/MainWindow.xaml.cs
+++ b/Navbot.RealtimeApi.Dotnet.SDK/Navbot.RealtimeApi.Dotnet.SDK.WPF.Sample/MainWindow.xaml.cs
@@ -97,6 +97,9 @@ namespace Navbot.RealtimeApi.Dotnet.SDK.WPF.Sample
                 pauseIcon.Visibility = Visibility.Visible;
 
                 realtimeApiWpfControl.StartSpeechRecognition();
+
+                // Disable talking mode by default
+                DisableTalkingMode();
             }
 
             isRecording = !isRecording;
@@ -141,10 +144,12 @@ namespace Navbot.RealtimeApi.Dotnet.SDK.WPF.Sample
             muteDelayCancellationTokenSource?.Cancel(); // Cancel any pending mute
             var muteCrossIcon = (System.Windows.Shapes.Path)PressToTalkButton.Template.FindName("MuteCrossIcon", PressToTalkButton);
             isMuted = false;
+            
             muteCrossIcon.Visibility = Visibility.Collapsed;
 
             // Unmute microphone
             realtimeApiWpfControl.RealtimeApiSdk.IsMuted = isMuted;
+            realtimeApiWpfControl.ReactToMicInput = true;
             log.Info("Microphone unmuted");
         }
 
@@ -156,6 +161,7 @@ namespace Navbot.RealtimeApi.Dotnet.SDK.WPF.Sample
 
             // Mute microphone
             realtimeApiWpfControl.RealtimeApiSdk.IsMuted = isMuted;
+            realtimeApiWpfControl.ReactToMicInput = false;
             log.Info("Microphone muted");
         }
 

--- a/Navbot.RealtimeApi.Dotnet.SDK/Navbot.RealtimeApi.Dotnet.SDK.WPF/RealtimeApiWpfControl.xaml.cs
+++ b/Navbot.RealtimeApi.Dotnet.SDK/Navbot.RealtimeApi.Dotnet.SDK.WPF/RealtimeApiWpfControl.xaml.cs
@@ -71,6 +71,8 @@ namespace Navbot.RealtimeApi.Dotnet.SDK.WPF
             set { RealtimeApiSdk.CustomInstructions = value; }
         }
 
+        public bool ReactToMicInput { get; set; } = false;
+
         private void RealtimeApiWpfControl_Loaded(object sender, RoutedEventArgs e)
         {
             if (this.Parent is FrameworkElement parent)
@@ -240,6 +242,7 @@ namespace Navbot.RealtimeApi.Dotnet.SDK.WPF
             {
                 // Start voice recognition;
                 RealtimeApiSdk.StartSpeechRecognitionAsync();
+                ReactToMicInput = true;
 
                 // Start ripple effect.
                 PlayVisualVoiceEffect(true);
@@ -252,6 +255,7 @@ namespace Navbot.RealtimeApi.Dotnet.SDK.WPF
             {
                 // Stop the ripple effect.
                 PlayVisualVoiceEffect(false);
+                ReactToMicInput = false;
 
                 // Stop voice recognition;
                 RealtimeApiSdk.StopSpeechRecognitionAsync();
@@ -269,7 +273,7 @@ namespace Navbot.RealtimeApi.Dotnet.SDK.WPF
             //RippleEffect.Visibility = voiceVisualEffect == WPF.VisualEffect.Cycle ? Visibility.Visible : Visibility.Collapsed;
             RippleEffect.Visibility = Visibility.Collapsed;
             cycleWaveformCanvas.Visibility = voiceVisualEffect == WPF.VisualEffect.Cycle ? Visibility.Visible : Visibility.Collapsed;
-
+            ReactToMicInput = enable;
 
             switch (voiceVisualEffect)
             {
@@ -304,6 +308,12 @@ namespace Navbot.RealtimeApi.Dotnet.SDK.WPF
 
         private void SpeechWaveIn_DataAvailable(object? sender, WaveInEventArgs e)
         {
+            if (!ReactToMicInput)
+            {
+                // Ignore microphone input
+                return;
+            }
+
             List<float> audioBuffer = new List<float>();
             for (int i = 0; i < e.BytesRecorded; i += 2)
             {


### PR DESCRIPTION
Solves Issue: https://github.com/fuwei007/OpenAI-realtimeapi-dotnetsdk/issues/13

- The RealTime control enables disabling and enabling the graphic effect for the microphone.
- The example now is disabling the mic effect upon start ("press-to-talk" is not pressed) and enables it when "press-to-talk" is pressed.