### PR TITLE
mitigate audio cutoffs issue, so part of the audio was lost "somewhere"

### DIFF
--- a/Navbot.RealtimeApi.Dotnet.SDK/Navbot.RealtimeApi.Dotnet.SDK.Core/NetworkProtocol/NetworkProtocolWebSocket.cs
+++ b/Navbot.RealtimeApi.Dotnet.SDK/Navbot.RealtimeApi.Dotnet.SDK.Core/NetworkProtocol/NetworkProtocolWebSocket.cs
@@ -275,6 +275,10 @@ namespace Navbot.RealtimeApi.Dotnet.SDK.Core
 
                 case ResponseDeltaType.AudioDone:
                     Log.Info($"Received json: {responseDelta}");
+                    // Issue: Audio cutoff sometimes is too early, so we need to wait for trailing audio deltas
+                    // see https://community.openai.com/t/realtime-api-audio-is-randomly-cutting-off-at-the-end/980587/44
+                    await Task.Delay(1000); // Some delay to receive trailing audio deltas
+                    
                     isModelResponding = false;
                     ResumeRecording();
                     break;


### PR DESCRIPTION
Added a delay after the audioDone event, to ensure all packages are received and processed - thus, reproduced.

Mitigates issue: https://github.com/fuwei007/OpenAI-realtimeapi-dotnetsdk/issues/73
(cannot be solved, as happens on the OpenAI model/servers)

I tested this over 2 medium conversations (15 interactions) without noticing any issues.

